### PR TITLE
Windows path fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "python-init-generator",
 	"displayName": "Python init Generator",
 	"description": "Generate Python __init__.py",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"engines": {
 		"vscode": "^1.38.0"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,8 @@ export function activate(context: vscode.ExtensionContext) {
 		// The code you place here will be executed every time your command is executed
 
 		const fileController = new FileController();
-		const rootPath = vscode.workspace.workspaceFolders?.[0]!.uri.path;
+		const rootPath = vscode.workspace.workspaceFolders?.[0]!.uri.fsPath.replace(/\\/g, "/");
+
 		if (rootPath !== null && rootPath !== undefined) {
 			const count = await fileController.generateInitFiles(rootPath);
 			vscode.window.showInformationMessage(`Python init Generator: Generate ${count} __init__.py file(s)`);

--- a/src/file-controller.ts
+++ b/src/file-controller.ts
@@ -98,9 +98,10 @@ export class FileController {
 
     public async generateInitFile(createDir: string): Promise<number> {
         let count = 0;
-        if (!fs.existsSync(path.join(createDir, "__init__.py"))) {
+        let init_path = path.join(createDir, "__init__.py");
+        if (!fs.existsSync(init_path)) {
             count++;
-            this.createFile(path.join(createDir, "__init__.py"));
+            this.createFile(init_path);
         }
 
         return count;


### PR DESCRIPTION
# Windows path fix
`vscode.workspace.workspaceFolders?.[0]!.uri.path` returns `/c:/foo/bar...`, so the file cannot be generated properly. 
First `/` character is the reason why the problem is occurred.

# How to fix
Use `vscode.workspace.workspaceFolders?.[0]!.uri.fsPath`, then replace all `\\` -> `/`
`fsPath` return OS dependent path, so need to replace `\\` on Windows.
Because of I don't know how to detect OS with VSCode API, then replace `\\` any OS.
