### PR TITLE
Fix empty ignoreDirectories problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "python-init-generator",
 	"displayName": "Python init Generator",
 	"description": "Generate Python __init__.py",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"engines": {
 		"vscode": "^1.74.0"
 	},

--- a/src/file-controller.ts
+++ b/src/file-controller.ts
@@ -32,10 +32,13 @@ export class FileController {
     /*
       Get all dirs which include *.{ext} file(s).
     */
-    const files = await glob.sync(path.join(rootDir, `/**/*.${ext}`));
+    const files = glob.sync(path.join(rootDir, `/**/*.${ext}`));
     const dirsSet = new Set<string>();
 
-    const excludeRegex = new RegExp(exclude.join("|"));
+    let excludeRegex: RegExp | undefined = undefined;
+    if (exclude.length !== 0) {
+      const excludeRegex = new RegExp(exclude.join("|"));
+    }
 
     files.forEach((file: string) => {
       const dir = path.dirname(file);
@@ -43,7 +46,7 @@ export class FileController {
       const relativeDir = path.relative(rootDir, dir);
 
       // Check if the relative directory path matches the combined exclude regex
-      if (!excludeRegex.test(relativeDir)) {
+      if (!excludeRegex?.test(relativeDir)) {
         dirsSet.add(dir);
       }
     });


### PR DESCRIPTION
I fixed empty ignoreDirectories problem.
If ignoreDirs is empty, this extension ignore all dirs.
I think this is not intuitive behavior.

